### PR TITLE
Update hexo-util dependency to ^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "hinastory",
   "license": "MIT",
   "dependencies": {
-    "hexo-util": "^0.6.3",
+    "hexo-util": "^3.1.0",
     "oembed": "^0.1.2"
   }
 }


### PR DESCRIPTION
Through a chain of dependencies the current version of `hexo-oembed` depends on a version of `highlight.js` that contains a ReDOS vulnerability.

Information on the vulnerability can be found at: https://github.com/advisories/GHSA-7wwv-vh3v-89cq

The chain of dependencies is:
`hexo-oembed 0.1.8` depends on `hexo-util ^0.6.3`, this in turn depends on `highlight ^9.4.0`.

The vulnerability exists in all versions of `highlight.js` from `9.0.0` to `10.4.0`.  This version range was required until `hexo-util 2.5.0` at which time it was updated to `10.7.0`.

After merge of this PR the version tagging will need to be incremented and a new release of the package to NPM will be required.